### PR TITLE
Don't show broken screenshot image

### DIFF
--- a/js/views/fill_attempts.js
+++ b/js/views/fill_attempts.js
@@ -18,7 +18,7 @@ define([
           time: moment(fill_attempt.attributes.run_at).format('MMMM Do YYYY, h:mm:ss a'),
           uid: x,
           tr_class: ++x % 2 == 0 ? "active" : "",
-          screenshot_url: config.CONTACT_CONGRESS_SERVER + "/" + fill_attempt.attributes.screenshot
+          screenshot_url: (fill_attempt.attributes.screenshot ? (config.CONTACT_CONGRESS_SERVER + "/" + fill_attempt.attributes.screenshot) : null)
         }, fill_attempt.attributes);
         if(fill_attempt.attributes.status == "error" || fill_attempt.attributes.status == "failure"){
           return Mustache.render(fillAttemptErrorTemplate, vals);

--- a/templates/fill_attempt_error.html
+++ b/templates/fill_attempt_error.html
@@ -3,9 +3,9 @@
     {{time}}
   </td>
   <td>
-    <span class="alert alert-danger">  
+    <span class="alert alert-danger">
       {{status}}
-    </span>  
+    </span>
   </td>
 </tr>
 <tr class='fill_additional_info_row {{tr_class}}' data-id='{{uid}}'>
@@ -13,8 +13,10 @@
     <pre class='error_info'>
       {{error}}
     </pre>
-    <div class='error_image'> 
+    {{#screenshot_url}}
+    <div class='error_image'>
       <img src='{{screenshot_url}}'>
     </div>
+    {{/screenshot_url}}
   </td>
 </tr>


### PR DESCRIPTION
Don't bother fetching the screenshot image URL when there is no available screenshot.
