### PR TITLE
Makes requests over HTTPS where possible

### DIFF
--- a/js/data/data.js
+++ b/js/data/data.js
@@ -1,5 +1,5 @@
 define([
-  'http://corsgithub.herokuapp.com/sinak/congress-zip-plus-four/master/legislators.json',
+  'https://corsgithub.herokuapp.com/sinak/congress-zip-plus-four/master/legislators.json',
 ], function(legislators) {
   return {
     legislators: legislators

--- a/js/main.js
+++ b/js/main.js
@@ -3,7 +3,7 @@ require.config({
     jquery: 'https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.0/jquery.min',
     lodash: 'https://cdnjs.cloudflare.com/ajax/libs/lodash.js/2.4.1/lodash.min',
     underscore: 'https://cdnjs.cloudflare.com/ajax/libs/underscore.js/1.6.0/underscore-min',
-    backbone: 'http://cdnjs.cloudflare.com/ajax/libs/backbone.js/1.1.2/backbone-min',
+    backbone: 'https://cdnjs.cloudflare.com/ajax/libs/backbone.js/1.1.2/backbone-min',
     mustache: 'https://cdnjs.cloudflare.com/ajax/libs/mustache.js/0.7.2/mustache.min',
     text: 'https://cdnjs.cloudflare.com/ajax/libs/require-text/2.0.10/text',
     marked: 'https://cdnjs.cloudflare.com/ajax/libs/marked/0.3.1/marked.min',
@@ -48,7 +48,7 @@ require([
     qs,
     Events,
     _,
-    jsyaml, 
+    jsyaml,
     marked,
     Data,
     fancybox,
@@ -67,12 +67,12 @@ require([
     legislatorStatusRowTemplate
   ){
   console.log(qs.get());
-  // Get the legislator id from query string 
+  // Get the legislator id from query string
   var bioguide_id = qs.get().bioguide_id || '';
 
   // Bring in Example data from YAML file
   $.ajax({
-    url: 'http://corsgithub.herokuapp.com/unitedstates/contact-congress/master/support/variables.yaml',
+    url: 'https://corsgithub.herokuapp.com/unitedstates/contact-congress/master/support/variables.yaml',
     success: function (exampleYaml) {
       var exampleData = jsyaml.load(exampleYaml);
       var examples = [];
@@ -166,7 +166,7 @@ require([
           success: function (legislator_obj) {
             cb(null, legislator_obj.results);
             return;
-          } 
+          }
         });
       }
     }, function(err, results){
@@ -219,7 +219,7 @@ require([
 
 
 
-/* 
+/*
 var helper = {
   dc_zips: [20001, 20002, 20003, 20004, 20005, 20006, 20007, 20008, 20009, 20010, 20011, 20012, 20015, 20016, 20017, 20018, 20019, 20020, 20024, 20032, 20036, 20037, 20045, 20052, 20053, 20057, 20064, 20202, 20204, 20228, 20230, 20240, 20245, 20260, 20307, 20317, 20319, 20373, 20390, 20405, 20418, 20427, 20506, 20510, 20520, 20535, 20540, 20551, 20553, 20560, 20565, 20566, 20593],
   zip_in_dc: function(zip){

--- a/templates/comments.html
+++ b/templates/comments.html
@@ -9,7 +9,7 @@
     var disqus_shortname = 'congressformstest'; // required: replace example with your forum shortname
     var disqus_identifier = '{{bioguide_id}}';
     var disqus_title = '{{first_name}} {{last_name}}';
-    var disqus_url = 'http://efforg.github.io/congress-forms-test/?bioguide_id={{bioguide_id}}';
+    var disqus_url = 'https://efforg.github.io/congress-forms-test/?bioguide_id={{bioguide_id}}';
     /* * * DON'T EDIT BELOW THIS LINE * * */
      (function() {
       var dsq = document.createElement('script');
@@ -19,8 +19,8 @@
       (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
     })();
     </script>
-    <noscript>Please enable JavaScript to view the <a href="http://disqus.com/?ref_noscript">comments powered by Disqus.</a>
+    <noscript>Please enable JavaScript to view the <a href="https://disqus.com/?ref_noscript">comments powered by Disqus.</a>
     </noscript>
-    <a href="http://disqus.com" class="dsq-brlink">comments powered by <span class="logo-disqus">Disqus</span></a>
+    <a href="https://disqus.com" class="dsq-brlink">comments powered by <span class="logo-disqus">Disqus</span></a>
   </div>
 </div>

--- a/templates/legislator.html
+++ b/templates/legislator.html
@@ -1,5 +1,5 @@
 <div class="thumbnail">
-  <img src="http://efforg.github.io/congress-forms-test/images/225x275/{{bioguide_id}}.jpg" alt="...">
+  <img src="https://efforg.github.io/congress-forms-test/images/225x275/{{bioguide_id}}.jpg" alt="...">
   <div class="caption">
     <strong>{{first_name}} {{last_name}}</strong>
     <br />


### PR DESCRIPTION
This will let the website run more smoothly when accessed over `https://` (which Github Pages [now supports](https://konklone.com/post/github-pages-now-supports-https-so-use-it) for `*.github.io` URLs).

I'm not sure whether this will actually work until it's merged. Though this fixes some errors, in development, the congress-forms server's CORS whitelisting blocked me from fetching content, and I don't know whether the change in protocol will disrupt the CORS whitelisting.

Either way, it will only help -- the site's already not working over HTTPS. Still, I'd like @legind or @sinak or someone with server control to merge this one, and add `https://efforg.github.io` to the list of CORS whitelisted servers.
